### PR TITLE
Add Jekyll portfolio site with blog support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,16 @@
 title: Abhishek Shah
-email: contact@abhishek-shah.org
-url: "https://abhishek-shah.org"
+email: contact@abhishek-shah.dev
+url: "https://abhishek-shah.dev"
 github_username: ashah2012
 twitter_username: avishek_20
+description: "Software engineer focused on AI and mathematics."
 
 markdown: kramdown
-theme: minima
+permalink: /blog/:year/:month/:day/:title/
 
 plugins:
   - jekyll-feed
+
+exclude:
+  - Gemfile
+  - Gemfile.lock

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{% if page.title and page.title != site.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | strip_newlines | truncate: 160 }}" />
+  <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="/feed.xml" />
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: #fff;
+      color: #111;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    .site-wrapper {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    /* Nav */
+    nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 40px 0 0;
+    }
+
+    .nav-name {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: #111;
+      text-decoration: none;
+      letter-spacing: -0.01em;
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 24px;
+      list-style: none;
+    }
+
+    .nav-links a {
+      font-size: 0.875rem;
+      color: #555;
+      text-decoration: none;
+      transition: color 0.15s ease;
+    }
+
+    .nav-links a:hover,
+    .nav-links a.active {
+      color: #111;
+    }
+
+    /* Main content */
+    main {
+      padding: 72px 0 96px;
+    }
+
+    /* Sections */
+    section {
+      margin-bottom: 52px;
+    }
+
+    .label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #999;
+      margin-bottom: 14px;
+    }
+
+    p {
+      font-size: 0.975rem;
+      color: #333;
+    }
+
+    /* Links row */
+    .links {
+      display: flex;
+      gap: 20px;
+      flex-wrap: wrap;
+    }
+
+    .links a {
+      font-size: 0.875rem;
+      color: #111;
+      text-decoration: none;
+      border-bottom: 1px solid #ccc;
+      padding-bottom: 1px;
+      transition: border-color 0.15s ease;
+    }
+
+    .links a:hover {
+      border-color: #111;
+    }
+
+    /* Blog post list */
+    .post-list {
+      list-style: none;
+    }
+
+    .post-list li {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 20px;
+      padding: 12px 0;
+      border-bottom: 1px solid #f0f0f0;
+    }
+
+    .post-list li:first-child {
+      border-top: 1px solid #f0f0f0;
+    }
+
+    .post-list a {
+      font-size: 0.925rem;
+      color: #111;
+      text-decoration: none;
+    }
+
+    .post-list a:hover {
+      text-decoration: underline;
+      text-decoration-color: #ccc;
+      text-underline-offset: 3px;
+    }
+
+    .post-date {
+      font-size: 0.78rem;
+      color: #aaa;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    /* Post content */
+    .post-header {
+      margin-bottom: 48px;
+    }
+
+    .post-title {
+      font-size: 1.5rem;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      line-height: 1.3;
+      margin-bottom: 10px;
+    }
+
+    .post-meta {
+      font-size: 0.8rem;
+      color: #aaa;
+    }
+
+    .post-content {
+      font-size: 0.975rem;
+      color: #333;
+    }
+
+    .post-content h2 {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #111;
+      margin: 36px 0 12px;
+      letter-spacing: -0.01em;
+    }
+
+    .post-content h3 {
+      font-size: 0.975rem;
+      font-weight: 600;
+      color: #111;
+      margin: 28px 0 10px;
+    }
+
+    .post-content p {
+      margin-bottom: 18px;
+    }
+
+    .post-content a {
+      color: #111;
+      text-underline-offset: 3px;
+    }
+
+    .post-content ul,
+    .post-content ol {
+      padding-left: 20px;
+      margin-bottom: 18px;
+    }
+
+    .post-content li {
+      margin-bottom: 6px;
+      font-size: 0.975rem;
+      color: #333;
+    }
+
+    .post-content code {
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      font-size: 0.85em;
+      background: #f5f5f5;
+      padding: 2px 5px;
+      border-radius: 3px;
+    }
+
+    .post-content pre {
+      background: #f5f5f5;
+      padding: 18px;
+      border-radius: 6px;
+      overflow-x: auto;
+      margin-bottom: 18px;
+    }
+
+    .post-content pre code {
+      background: none;
+      padding: 0;
+      font-size: 0.85rem;
+    }
+
+    .post-content blockquote {
+      border-left: 3px solid #e0e0e0;
+      padding-left: 18px;
+      margin: 24px 0;
+      color: #666;
+    }
+
+    /* Back link */
+    .back-link {
+      display: inline-block;
+      font-size: 0.825rem;
+      color: #999;
+      text-decoration: none;
+      margin-bottom: 48px;
+    }
+
+    .back-link:hover {
+      color: #111;
+    }
+
+    /* Page title */
+    .page-title {
+      font-size: 1.75rem;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      margin-bottom: 40px;
+    }
+
+    /* Footer */
+    footer {
+      padding: 32px 0 48px;
+      border-top: 1px solid #f0f0f0;
+    }
+
+    footer p {
+      font-size: 0.78rem;
+      color: #bbb;
+    }
+  </style>
+</head>
+<body>
+  <div class="site-wrapper">
+    <nav>
+      <a href="/" class="nav-name">{{ site.title }}</a>
+      <ul class="nav-links">
+        <li><a href="/" {% if page.url == '/' %}class="active"{% endif %}>About</a></li>
+        <li><a href="/blog" {% if page.url contains '/blog' %}class="active"{% endif %}>Blog</a></li>
+      </ul>
+    </nav>
+
+    <main>
+      {{ content }}
+    </main>
+
+    <footer>
+      <p>&copy; {{ 'now' | date: "%Y" }} {{ site.title }}</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,15 @@
+---
+layout: default
+---
+<a href="/blog" class="back-link">← Blog</a>
+
+<article>
+  <header class="post-header">
+    <h1 class="post-title">{{ page.title }}</h1>
+    <p class="post-meta">{{ page.date | date: "%B %-d, %Y" }}</p>
+  </header>
+
+  <div class="post-content">
+    {{ content }}
+  </div>
+</article>

--- a/_posts/2026-06-14-understanding-backpropagation.md
+++ b/_posts/2026-06-14-understanding-backpropagation.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: "Understanding Backpropagation from Scratch"
+date: 2026-06-14
+---
+
+Backpropagation is the algorithm that makes neural networks learn. Despite its reputation as a black box, it's really just the chain rule from calculus applied systematically across a computation graph.
+
+## The Core Idea
+
+A neural network is a function composed of many simpler functions. Training it means finding weights that minimize a loss function — typically the difference between predicted and actual outputs. Gradient descent does this iteratively: compute how much each weight contributes to the loss, then nudge it in the opposite direction.
+
+Backpropagation is how we compute those gradients efficiently.
+
+## A Simple Example
+
+Consider a two-layer network with a single training example. The forward pass computes:
+
+```
+z1 = W1 * x + b1
+a1 = relu(z1)
+z2 = W2 * a1 + b2
+loss = (a2 - y)^2
+```
+
+The backward pass works in reverse, computing `dLoss/dW` for every weight by repeatedly applying the chain rule:
+
+```
+dLoss/dW2 = dLoss/da2 * da2/dz2 * dz2/dW2
+```
+
+Each term is easy to compute locally. The key insight is that each layer only needs the gradient flowing in from the layer ahead of it — this is what makes backprop efficient.
+
+## Why It Matters
+
+Before backpropagation, training deep networks was largely intractable. The 1986 paper by Rumelhart, Hinton, and Williams popularized the algorithm and kicked off the first wave of neural network research. Forty years later, the same fundamental algorithm powers systems with hundreds of billions of parameters.
+
+Understanding it at this level — not just using it via `loss.backward()` — changes how you think about network architecture, initialization, and why certain training problems (like vanishing gradients) happen in the first place.
+
+## Next Steps
+
+If you want to go deeper, implement a small autograd engine from scratch. Andrej Karpathy's [micrograd](https://github.com/karpathy/micrograd) is an excellent reference — around 150 lines of Python that implement the core of what PyTorch does under the hood.

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Blog
+---
+<h1 class="page-title">Blog</h1>
+
+{% if site.posts.size > 0 %}
+  <ul class="post-list">
+    {% for post in site.posts %}
+      <li>
+        <a href="{{ post.url }}">{{ post.title }}</a>
+        <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+      </li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <p>No posts yet.</p>
+{% endif %}

--- a/index.html
+++ b/index.html
@@ -1,101 +1,17 @@
 ---
-layout: none
+layout: default
 ---
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Abhishek Shah</title>
-  <style>
-    *, *::before, *::after {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-    }
+<section>
+  <p class="label">About</p>
+  <p>Software engineer with a degree in Computer Science &amp; Engineering. Currently focused on deeply understanding AI — particularly the mathematics behind it. Outside of work, enjoys video games.</p>
+</section>
 
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-      background: #fff;
-      color: #111;
-      line-height: 1.6;
-      min-height: 100vh;
-    }
-
-    main {
-      max-width: 600px;
-      margin: 0 auto;
-      padding: 96px 24px 96px;
-    }
-
-    header {
-      margin-bottom: 72px;
-    }
-
-    h1 {
-      font-size: 1.75rem;
-      font-weight: 600;
-      letter-spacing: -0.02em;
-    }
-
-    section {
-      margin-bottom: 52px;
-    }
-
-    .label {
-      font-size: 0.7rem;
-      font-weight: 600;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      color: #999;
-      margin-bottom: 14px;
-    }
-
-    p {
-      font-size: 0.975rem;
-      color: #333;
-    }
-
-    .links {
-      display: flex;
-      gap: 20px;
-      flex-wrap: wrap;
-    }
-
-    .links a {
-      font-size: 0.875rem;
-      color: #111;
-      text-decoration: none;
-      border-bottom: 1px solid #ccc;
-      padding-bottom: 1px;
-      transition: border-color 0.15s ease;
-    }
-
-    .links a:hover {
-      border-color: #111;
-    }
-  </style>
-</head>
-<body>
-  <main>
-    <header>
-      <h1>Abhishek Shah</h1>
-    </header>
-
-    <section>
-      <p class="label">About</p>
-      <p>Software engineer with a degree in Computer Science &amp; Engineering. Currently focused on deeply understanding AI — particularly the mathematics behind it. Outside of work, enjoys video games.</p>
-    </section>
-
-    <section>
-      <p class="label">Contact</p>
-      <div class="links">
-        <a href="mailto:contact@abhishek-shah.org">Email</a>
-        <a href="https://github.com/ashah2012" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://www.linkedin.com/in/abhishekshah20/" target="_blank" rel="noopener">LinkedIn</a>
-        <a href="https://twitter.com/avishek_20" target="_blank" rel="noopener">Twitter</a>
-      </div>
-    </section>
-  </main>
-</body>
-</html>
+<section>
+  <p class="label">Contact</p>
+  <div class="links">
+    <a href="mailto:contact@abhishek-shah.dev">Email</a>
+    <a href="https://github.com/ashah2012" target="_blank" rel="noopener">GitHub</a>
+    <a href="https://www.linkedin.com/in/abhishekshah20/" target="_blank" rel="noopener">LinkedIn</a>
+    <a href="https://twitter.com/avishek_20" target="_blank" rel="noopener">Twitter</a>
+  </div>
+</section>


### PR DESCRIPTION
- Replace single-file layout-none page with proper Jekyll structure
- Add custom default and post layouts with clean minimal design
- Add blog listing page at /blog with date-sorted post list
- Add sample post on backpropagation
- Update _config.yml: remove minima theme, set permalink, fix email domain

https://claude.ai/code/session_01FmyYfTzTCmLoVa4rLAqyqW