### PR TITLE
Fix duplicated Projects section on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,22 +23,6 @@ layout: default
 </section>
 
 <section>
-  <p class="label">Projects</p>
-  <ul class="project-list">
-    <li>
-      <a class="project-title" href="https://dev.settleup.co.in" target="_blank" rel="noopener">Wallet</a>
-      <p class="project-desc">A super-charged B2B wallet for Indian retailers to pay bills, book flights, hotels, and buses, and purchase gift cards for their customers.</p>
-      <p class="project-stack">React · Spring Boot · Kotlin</p>
-    </li>
-    <li>
-      <a class="project-title" href="https://constructik.com" target="_blank" rel="noopener">Constructik</a>
-      <p class="project-desc">A SaaS platform for construction development and project management.</p>
-      <p class="project-stack">React · Spring Boot · Java</p>
-    </li>
-  </ul>
-</section>
-
-<section>
   <p class="label">Contact</p>
   <div class="links">
     <a href="mailto:contact@abhishek-shah.dev">Email</a>


### PR DESCRIPTION
## Summary
- `index.html` had the Projects section (Wallet + Constructik) appearing twice in a row on the live site, due to a duplicate landing alongside the squash-merge of PR #32.
- Removes the second, duplicate `<section>` block, leaving exactly one Projects section between About and Contact.

## Test plan
- [x] Verified only one `Projects` label remains in `index.html`
- [x] Confirmed CSS in `_layouts/default.html` was not duplicated (only the HTML markup was)


---
_Generated by [Claude Code](https://claude.ai/code/session_018s2eyWjdKGmnvPmPp68P5e)_