### PR TITLE
Convert About section to bullet points

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -96,6 +96,26 @@
       color: #333;
     }
 
+    /* About list */
+    .about-list {
+      list-style: none;
+      font-size: 0.975rem;
+      color: #333;
+    }
+
+    .about-list li {
+      position: relative;
+      padding-left: 16px;
+      margin-bottom: 10px;
+    }
+
+    .about-list li::before {
+      content: "—";
+      position: absolute;
+      left: 0;
+      color: #ccc;
+    }
+
     /* Links row */
     .links {
       display: flex;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,13 @@ layout: default
 ---
 <section>
   <p class="label">About</p>
-  <p>Backend engineer with 11 years of experience building APIs and data systems across the finance industry. Currently a Software Developer at UBS in Doha, working on backend APIs for portfolio details and performance reporting. Previously built systems at Credit Suisse, PwC, and Cognizant, with a focus on data engineering and distributed APIs. Holds a B.Tech in Computer Science &amp; Engineering from West Bengal University of Technology. Outside of work, deeply focused on understanding AI — particularly the mathematics behind it — and enjoys video games.</p>
+  <ul class="about-list">
+    <li>Backend engineer with 11 years of experience building APIs and data systems across the finance industry.</li>
+    <li>Currently a Software Developer at UBS in Doha, working on backend APIs for portfolio details and performance reporting.</li>
+    <li>Previously built systems at Credit Suisse, PwC, and Cognizant, with a focus on data engineering and distributed APIs.</li>
+    <li>B.Tech in Computer Science &amp; Engineering, West Bengal University of Technology.</li>
+    <li>Outside of work, deeply focused on understanding AI — particularly the mathematics behind it — and enjoys video games.</li>
+  </ul>
 </section>
 
 <section>


### PR DESCRIPTION
## Summary
- Replaced the single About paragraph with a bullet list for easier scanning.
- Added `.about-list` styling (no bullets, subtle dash marker) consistent with the site's minimal aesthetic.

## Test plan
- [x] Verified the page renders correctly via Liquid template check (no jekyll build available in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_018s2eyWjdKGmnvPmPp68P5e)_